### PR TITLE
Fix link to typescript draft conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Refactor the application to use ReduxJS.
 (Any view models you will need no not have to be instances of Immutable, just use POJO.)
 
 ## Task 4
-In this task you will use TypeScript to make you app strongly typed. Mainly introduce interfaces for all Models and ViewModels in your app. Use them in reducers. Create a simple interface for action with payload of type `any` and use it for all actions. Rewrite all components, and redux stuff to TypeScript - have a look at [Draft coding conventions](https://kentico.atlassian.net/wiki/display/KC/Javascript+and+Typescript+Conventions) on wiki to get an idea how to start. Tests may remain written in JS, however all new tests should leverage TypeScript.
+In this task you will use TypeScript to make you app strongly typed. Mainly introduce interfaces for all Models and ViewModels in your app. Use them in reducers. Create a simple interface for action with payload of type `any` and use it for all actions. Rewrite all components, and redux stuff to TypeScript - have a look at [Draft coding conventions](https://kentico.atlassian.net/wiki/spaces/KCD/pages/211791711/Javascript+and+Typescript+Conventions) on wiki to get an idea how to start. Tests may remain written in JS, however all new tests should leverage TypeScript.
 
 **IMPORTANT:**
 Make sure you install type definitions for all 3rd party libraries you are already using in your app (e.g. redux, react-redux, immutable, memoizee...). To do that, run this for each library:


### PR DESCRIPTION
When I tried to read Draft coding conventions for typescript I was redirected to not existing page on the wiki. Due to that, I changed URL for Draft coding conventions.